### PR TITLE
fix(webhook): honor webhook_allowed_internal_domains in pre-flight URL validation

### DIFF
--- a/fastsmtp/src/fastsmtp/api/operations.py
+++ b/fastsmtp/src/fastsmtp/api/operations.py
@@ -238,6 +238,7 @@ async def retry_delivery_endpoint(
 async def test_webhook(
     data: TestWebhookRequest,
     auth: Auth,
+    settings: Settings = Depends(get_settings),
 ) -> TestWebhookResponse:
     """Test a webhook URL by sending a test payload."""
     # Require authentication
@@ -273,6 +274,7 @@ async def test_webhook(
         url=str(data.webhook_url),
         payload=payload,
         request_timeout=30.0,
+        allowed_internal_domains=settings.webhook_allowed_internal_domains,
     )
     elapsed_ms = (time.time() - start_time) * 1000
 

--- a/fastsmtp/src/fastsmtp/webhook/dispatcher.py
+++ b/fastsmtp/src/fastsmtp/webhook/dispatcher.py
@@ -35,6 +35,7 @@ async def send_webhook(
     request_timeout: float = 30.0,
     client: httpx.AsyncClient | None = None,
     validate_url: bool = True,
+    allowed_internal_domains: list[str] | None = None,
 ) -> tuple[bool, int | None, str | None]:
     """Send a webhook request.
 
@@ -45,6 +46,10 @@ async def send_webhook(
         request_timeout: Request timeout in seconds
         client: HTTP client to use (required for production use)
         validate_url: Whether to validate URL for SSRF protection (default True)
+        allowed_internal_domains: Hostnames permitted to resolve to private IPs.
+            Required when delivering to internal targets (e.g. cluster-local
+            services); the SSRF-safe client must also be created with the same
+            allowlist for the bypass to take effect at connect time.
 
     Returns:
         Tuple of (success, status_code, error_message)
@@ -52,7 +57,11 @@ async def send_webhook(
     # Validate URL for SSRF protection
     if validate_url:
         try:
-            validate_webhook_url(url, resolve_dns=True)
+            validate_webhook_url(
+                url,
+                resolve_dns=True,
+                allowed_internal_domains=allowed_internal_domains,
+            )
         except SSRFError as e:
             logger.warning(f"Blocked webhook to {url}: {e}")
             return False, None, f"URL blocked: {e}"
@@ -69,7 +78,10 @@ async def send_webhook(
     # Create a temporary client if none provided (for testing/one-off use)
     close_client = False
     if client is None:
-        client = create_ssrf_safe_client(timeout=request_timeout)
+        client = create_ssrf_safe_client(
+            timeout=request_timeout,
+            allowed_internal_domains=allowed_internal_domains,
+        )
         close_client = True
 
     try:
@@ -135,6 +147,7 @@ async def process_delivery(
         headers=headers,
         request_timeout=settings.webhook_timeout,
         client=client,
+        allowed_internal_domains=settings.webhook_allowed_internal_domains,
     )
 
     # Record delivery duration

--- a/fastsmtp/src/fastsmtp/webhook/queue.py
+++ b/fastsmtp/src/fastsmtp/webhook/queue.py
@@ -63,6 +63,7 @@ async def _send_dlq_notification(
                 request_timeout=10.0,
                 client=client,
                 validate_url=True,
+                allowed_internal_domains=settings.webhook_allowed_internal_domains,
             )
             if success:
                 logger.info(f"DLQ notification sent for delivery {delivery.id}")

--- a/fastsmtp/src/fastsmtp/webhook/url_validator.py
+++ b/fastsmtp/src/fastsmtp/webhook/url_validator.py
@@ -67,12 +67,34 @@ def is_ip_blocked(ip_str: str) -> bool:
         return False
 
 
-def validate_webhook_url(url: str, resolve_dns: bool = True) -> None:
+def is_host_in_allowlist(host: str, allowed_internal_domains: list[str] | None) -> bool:
+    """Check if a host matches an entry in the internal-domains allowlist.
+
+    A host matches if it equals an allowed entry exactly or is a subdomain of it.
+    """
+    if not allowed_internal_domains:
+        return False
+    host_lower = host.lower()
+    for allowed in allowed_internal_domains:
+        allowed_lower = allowed.lower()
+        if host_lower == allowed_lower or host_lower.endswith("." + allowed_lower):
+            return True
+    return False
+
+
+def validate_webhook_url(
+    url: str,
+    resolve_dns: bool = True,
+    allowed_internal_domains: list[str] | None = None,
+) -> None:
     """Validate a webhook URL for SSRF protection.
 
     Args:
         url: The URL to validate
         resolve_dns: Whether to resolve DNS and check the resolved IP
+        allowed_internal_domains: Hostnames (and subdomains thereof) that are
+            permitted to resolve to otherwise-blocked private/internal IPs.
+            Intended for in-cluster service discovery via split-horizon DNS.
 
     Raises:
         SSRFError: If the URL is blocked due to SSRF protection
@@ -95,6 +117,12 @@ def validate_webhook_url(url: str, resolve_dns: bool = True) -> None:
 
     # Normalize hostname
     hostname_lower = hostname.lower()
+
+    # Allowlisted hostnames bypass the rest of the SSRF checks. The connection
+    # pool (SSRFSafeAsyncConnectionPool) applies the same allowlist at connect
+    # time, so DNS rebinding is still mitigated.
+    if is_host_in_allowlist(hostname, allowed_internal_domains):
+        return
 
     # Check against blocked hostnames
     if hostname_lower in BLOCKED_HOSTNAMES:
@@ -130,18 +158,28 @@ def validate_webhook_url(url: str, resolve_dns: bool = True) -> None:
             pass
 
 
-def is_url_safe(url: str, resolve_dns: bool = True) -> tuple[bool, str | None]:
+def is_url_safe(
+    url: str,
+    resolve_dns: bool = True,
+    allowed_internal_domains: list[str] | None = None,
+) -> tuple[bool, str | None]:
     """Check if a URL is safe for webhook delivery.
 
     Args:
         url: The URL to check
         resolve_dns: Whether to resolve DNS and check the resolved IP
+        allowed_internal_domains: Hostnames permitted to bypass the
+            private-IP block (see ``validate_webhook_url``).
 
     Returns:
         Tuple of (is_safe, error_message)
     """
     try:
-        validate_webhook_url(url, resolve_dns=resolve_dns)
+        validate_webhook_url(
+            url,
+            resolve_dns=resolve_dns,
+            allowed_internal_domains=allowed_internal_domains,
+        )
         return True, None
     except (SSRFError, ValueError) as e:
         return False, str(e)
@@ -160,17 +198,7 @@ class SSRFSafeAsyncConnectionPool(httpcore.AsyncConnectionPool):
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
-        # Normalize allowed domains to lowercase for comparison
-        self._allowed_domains = {d.lower() for d in (allowed_internal_domains or [])}
-
-    def _is_domain_allowed(self, host: str) -> bool:
-        """Check if a domain is in the allowed internal domains list."""
-        host_lower = host.lower()
-        # Exact match or subdomain match
-        for allowed in self._allowed_domains:
-            if host_lower == allowed or host_lower.endswith("." + allowed):
-                return True
-        return False
+        self._allowed_domains = list(allowed_internal_domains or [])
 
     async def handle_async_request(self, request: httpcore.Request) -> httpcore.Response:
         """Handle request with IP validation at connection time."""
@@ -183,7 +211,7 @@ class SSRFSafeAsyncConnectionPool(httpcore.AsyncConnectionPool):
             host = host.decode("ascii")
 
         # Check if domain is in allowlist (bypass SSRF protection)
-        if self._is_domain_allowed(host):
+        if is_host_in_allowlist(host, self._allowed_domains):
             return await super().handle_async_request(request)
 
         # Check blocked hostnames

--- a/fastsmtp/tests/test_url_validator.py
+++ b/fastsmtp/tests/test_url_validator.py
@@ -1,8 +1,11 @@
 """Tests for webhook URL validation (SSRF protection)."""
 
+from unittest.mock import patch
+
 import pytest
 from fastsmtp.webhook.url_validator import (
     SSRFError,
+    is_host_in_allowlist,
     is_ip_blocked,
     is_url_safe,
     validate_webhook_url,
@@ -127,6 +130,88 @@ class TestValidateWebhookUrl:
         """Test that IPv6 localhost is blocked."""
         with pytest.raises(SSRFError, match="blocked range"):
             validate_webhook_url("http://[::1]/webhook", resolve_dns=False)
+
+
+class TestAllowedInternalDomains:
+    """Tests for the allowed_internal_domains bypass."""
+
+    def test_exact_match_bypasses_dns_block(self):
+        """An allowlisted hostname resolving to a private IP is permitted."""
+
+        def fake_getaddrinfo(host, port, **kwargs):
+            return [(2, 1, 6, "", ("10.6.8.8", port))]
+
+        with patch("socket.getaddrinfo", side_effect=fake_getaddrinfo):
+            # Without allowlist: blocked
+            with pytest.raises(SSRFError, match="blocked IP"):
+                validate_webhook_url("https://n8n.metrooptic.com/hook")
+            # With allowlist: permitted
+            validate_webhook_url(
+                "https://n8n.metrooptic.com/hook",
+                allowed_internal_domains=["n8n.metrooptic.com"],
+            )
+
+    def test_subdomain_match_bypasses_dns_block(self):
+        """A host that is a subdomain of an allowed entry is permitted."""
+
+        def fake_getaddrinfo(host, port, **kwargs):
+            return [(2, 1, 6, "", ("10.0.0.5", port))]
+
+        with patch("socket.getaddrinfo", side_effect=fake_getaddrinfo):
+            validate_webhook_url(
+                "https://api.internal.example/hook",
+                allowed_internal_domains=["internal.example"],
+            )
+
+    def test_match_is_case_insensitive(self):
+        """Allowlist matching ignores case on both sides."""
+
+        def fake_getaddrinfo(host, port, **kwargs):
+            return [(2, 1, 6, "", ("10.0.0.5", port))]
+
+        with patch("socket.getaddrinfo", side_effect=fake_getaddrinfo):
+            validate_webhook_url(
+                "https://N8N.Metrooptic.COM/hook",
+                allowed_internal_domains=["n8n.metrooptic.com"],
+            )
+
+    def test_partial_suffix_does_not_match(self):
+        """A hostname that merely shares a suffix substring is not allowed."""
+        assert is_host_in_allowlist("evilexample.com", ["example.com"]) is False
+        assert is_host_in_allowlist("example.com.evil", ["example.com"]) is False
+
+    def test_blocked_hostname_still_blocked_when_not_allowlisted(self):
+        """Allowlist does not match, so a blocked literal hostname is still blocked."""
+        with pytest.raises(SSRFError, match="blocked"):
+            validate_webhook_url(
+                "http://localhost/hook",
+                resolve_dns=False,
+                allowed_internal_domains=["other.example"],
+            )
+
+    def test_allowlisted_localhost_is_permitted(self):
+        """An explicitly allowlisted hostname bypasses the BLOCKED_HOSTNAMES set."""
+        # Skip DNS resolution by using a hostname that will be allowlisted before
+        # the IP lookup runs.
+        validate_webhook_url(
+            "http://localhost/hook",
+            resolve_dns=False,
+            allowed_internal_domains=["localhost"],
+        )
+
+    def test_is_url_safe_threads_allowlist(self):
+        """is_url_safe forwards the allowlist to validate_webhook_url."""
+
+        def fake_getaddrinfo(host, port, **kwargs):
+            return [(2, 1, 6, "", ("10.6.8.8", port))]
+
+        with patch("socket.getaddrinfo", side_effect=fake_getaddrinfo):
+            ok, err = is_url_safe(
+                "https://n8n.metrooptic.com/hook",
+                allowed_internal_domains=["n8n.metrooptic.com"],
+            )
+            assert ok is True
+            assert err is None
 
 
 class TestIsUrlSafe:


### PR DESCRIPTION
## Summary

`webhook_allowed_internal_domains` was advertised as the way to allow webhook delivery to in-cluster / split-horizon hostnames that resolve to private IPs, but it had no effect:

- `send_webhook()` (`webhook/dispatcher.py`) calls `validate_webhook_url()` before any HTTP request.
- `validate_webhook_url()` (`webhook/url_validator.py`) did not accept an allowlist and unconditionally raised `SSRFError` on RFC1918 / loopback resolutions.
- The allowlist was only honored at the `SSRFSafeAsyncConnectionPool` layer, which is only reached *after* validation succeeds.

Net result: setting `FASTSMTP_WEBHOOK_ALLOWED_INTERNAL_DOMAINS=["n8n.metrooptic.com"]` on a deployment still produced `URL blocked: Hostname 'n8n.metrooptic.com' resolves to blocked IP '10.6.8.8'` for both regular delivery and `POST /api/v1/test-webhook`.

This PR plumbs the allowlist all the way through:

- `validate_webhook_url()` and `is_url_safe()` accept `allowed_internal_domains` and short-circuit on a match (exact host or subdomain, case-insensitive).
- `send_webhook()` accepts and forwards it to the validator and to the auto-created SSRF-safe client when no client is supplied.
- `process_delivery` (worker path), the `/test-webhook` API endpoint, and the DLQ notification path all pass `settings.webhook_allowed_internal_domains`.
- Connection-pool matching is refactored onto a shared `is_host_in_allowlist()` helper so the validator and the pool cannot drift on what counts as a match.

The connection-pool layer still re-validates resolved IPs at connect time for hosts *not* on the allowlist, so DNS-rebinding protection is unchanged for non-allowlisted destinations.

## Test plan

- [x] `pytest fastsmtp/tests/test_url_validator.py` — 29 passed (22 pre-existing + 7 new covering exact match, subdomain match, case-insensitivity, partial-suffix non-match, allowlisted blocked-hostname literal, `is_url_safe` propagation).
- [x] `pytest fastsmtp/tests/test_webhook.py` — 52 passed (no regressions; existing tests unaffected because the new param defaults to `None`).
- [x] `pytest fastsmtp/tests` (full suite excluding `test_smtp_integration.py`) — 569 passed.
- [ ] Verify in cluster: bump image, redeploy `fastsmtp`, re-run `POST /api/v1/test-webhook` against `https://n8n.metrooptic.com/webhook/...` — expect `success: true`.